### PR TITLE
peer: set context peer for Exec requests

### DIFF
--- a/chirp_test.go
+++ b/chirp_test.go
@@ -318,6 +318,18 @@ func TestPeerExec(t *testing.T) {
 			t.Errorf("Call 3: response is %v, want nil", rsp)
 		}
 	})
+	t.Run("HasContextPeer", func(t *testing.T) {
+		loc.B.Handle("?", func(ctx context.Context, _ *chirp.Request) ([]byte, error) {
+			return parseTestSpec(ctx, "peer?")
+		})
+		rsp, err := loc.B.Exec(context.Background(), "?", nil)
+		if err != nil {
+			t.Fatalf("Exec probe: unexpected error: %v", err)
+		}
+		if got := string(rsp); got != "present" {
+			t.Errorf("Exec probe: got %q, want present", got)
+		}
+	})
 }
 
 func TestSlowCancellation(t *testing.T) {

--- a/peer.go
+++ b/peer.go
@@ -331,6 +331,9 @@ func (p *Peer) Exec(ctx context.Context, method string, data []byte) ([]byte, er
 	if !ok {
 		return nil, errUnknownMethod{}
 	}
+	if ContextPeer(ctx) == nil {
+		ctx = context.WithValue(ctx, peerContextKey{}, p)
+	}
 	return handler(ctx, &Request{Method: method, Data: data})
 }
 


### PR DESCRIPTION
I overlooked this when adding peer context. Add the current peer if there is
not already one set.
